### PR TITLE
Allow custom options to be passed to TerminalNotifier

### DIFF
--- a/lib/minitest/osx_plugin.rb
+++ b/lib/minitest/osx_plugin.rb
@@ -7,6 +7,9 @@ module Minitest
   end
 
   class OsxNotificationReporter < StatisticsReporter
+
+    cattr_accessor :notifier_options
+
     def report
       super
 
@@ -14,7 +17,7 @@ module Minitest
 
       title = (passed? ? "Successful \u{1f497}" : "Failed \u{1f4a9}")
 
-      TerminalNotifier.notify(text, :title => 'Minitest', :subtitle => title)
+      TerminalNotifier.notify(text, self.notifier_options.merge({:title => 'Minitest', :subtitle => title}) )
     end
   end
 end

--- a/lib/minitest/osx_plugin.rb
+++ b/lib/minitest/osx_plugin.rb
@@ -10,6 +10,8 @@ module Minitest
 
     cattr_accessor :notifier_options
 
+    @@notifier_options = {}
+
     def report
       super
 

--- a/minitest-osx.gemspec
+++ b/minitest-osx.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "minitest", "~> 5.4"
-  spec.add_dependency "terminal-notifier", "~> 1.6"
+  spec.add_dependency "terminal-notifier", "~> 2.0"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.3"


### PR DESCRIPTION
For example, you can now do this:
```ruby
require 'minitest/osx'
  Minitest::OsxNotificationReporter.notifier_options = {
    activate: 'com.apple.Terminal',
    group: 'my_test_suite',
    timeout: 5,
  }
```
Which will re-open the Terminal app when the notification is clicked, and only display one notification for test reports, rather than stacking them.

As part of this, I had to update TestNotifier to 2.0 as they had a bug in previous versions which blocked minitest from completing while waiting for the user to interact with the notification.